### PR TITLE
Add support to disable the whole chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add support to disable the whole chart if logging is disabled at the installation level.
+
 ## [0.7.0] - 2024-09-17
 
 ### Added

--- a/helm/grafana-multi-tenant-proxy/templates/auth-secret.yaml
+++ b/helm/grafana-multi-tenant-proxy/templates/auth-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if .Values.proxy.deployCredentials }}
 apiVersion: v1
 kind: Secret
@@ -8,4 +9,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   authn.yaml: {{ .Values.proxy.credentials | b64enc }}
+{{- end }}
 {{- end }}

--- a/helm/grafana-multi-tenant-proxy/templates/ciliumnetworkpolicy.yaml
+++ b/helm/grafana-multi-tenant-proxy/templates/ciliumnetworkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if and (.Values.networkPolicy.enabled) (eq .Values.networkPolicy.flavor "cilium") }}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -15,4 +16,5 @@ spec:
     - ports: 
       - port: http
         protocol: TCP
+{{- end }}
 {{- end }}

--- a/helm/grafana-multi-tenant-proxy/templates/config.yaml
+++ b/helm/grafana-multi-tenant-proxy/templates/config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,3 +9,4 @@ metadata:
 data:
   config.yaml: |
     targetServers: {{- tpl (toYaml .Values.proxy.targetServers) . | nindent 6 }}
+{{- end }}

--- a/helm/grafana-multi-tenant-proxy/templates/deployment.yaml
+++ b/helm/grafana-multi-tenant-proxy/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -73,3 +74,4 @@ spec:
                   name: {{ include "proxy.fullname" $ }}-auth-config
               - configMap:
                   name: {{ include "proxy.fullname" $ }}-config
+{{- end }}

--- a/helm/grafana-multi-tenant-proxy/templates/hpa.yaml
+++ b/helm/grafana-multi-tenant-proxy/templates/hpa.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- $autoscalingv2 := .Capabilities.APIVersions.Has "autoscaling/v2" -}}
 {{- if .Values.proxy.autoscaling.enabled }}
 {{- if $autoscalingv2 }}
@@ -43,4 +44,5 @@ spec:
         targetAverageUtilization: {{ . }}
         {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/helm/grafana-multi-tenant-proxy/templates/ingress.yaml
+++ b/helm/grafana-multi-tenant-proxy/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -42,4 +43,5 @@ spec:
                   number: {{ $.Values.service.port }}
           {{- end }}
     {{- end }}
+{{- end }}
 {{- end }}

--- a/helm/grafana-multi-tenant-proxy/templates/service.yaml
+++ b/helm/grafana-multi-tenant-proxy/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
     targetPort: http
   selector:
     {{- include "proxy.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/grafana-multi-tenant-proxy/templates/servicemonitor.yaml
+++ b/helm/grafana-multi-tenant-proxy/templates/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if .Values.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -13,4 +14,5 @@ spec:
   endpoints:
     - port: http
       path: /metrics
+{{- end }}
 {{- end }}

--- a/helm/grafana-multi-tenant-proxy/values.yaml
+++ b/helm/grafana-multi-tenant-proxy/values.yaml
@@ -3,6 +3,8 @@ nameOverride: null
 # -- Overrides the chart's computed fullname
 fullnameOverride: null
 
+enabled: true
+
 global:
   image:
     # -- Overrides the Docker registry globally for all images


### PR DESCRIPTION
This PR adds support to disable the whole chart components to not create if on installations where logging is disabled.

This is causing issues when running mc-bootstrap on ephemeral installations as this container is deployed but is constantly failing to start because the logging operator is not creating the required secrets